### PR TITLE
feat: batch files

### DIFF
--- a/Senior_Resident_Scheudling.bat
+++ b/Senior_Resident_Scheudling.bat
@@ -1,0 +1,10 @@
+@echo off
+
+:: Run npm start
+npm start
+
+:: Open Chrome browser with the specified URL
+:: start chrome "http://localhost:3000"
+
+:: Prevent the terminal from closing immediately
+pause

--- a/Senior_Resident_Scheudling.bat
+++ b/Senior_Resident_Scheudling.bat
@@ -1,10 +1,10 @@
 @echo off
 
+:: Open Chrome browser with the specified URL
+start chrome "http://localhost:3000"
+
 :: Run npm start
 npm start
-
-:: Open Chrome browser with the specified URL
-:: start chrome "http://localhost:3000"
 
 :: Prevent the terminal from closing immediately
 pause

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "node-binary\\node node_modules\\vite\\bin\\vite.js",
-    "server": "node-binary\\node node_modules\\json-server\\lib\\cli\\bin.js --watch db.json --port 4000",
+    "dev": "vite",
+    "server": "json-server --watch db.json --port 4000",
     "start": "concurrently \"npm:dev\" \"npm:server\"",
-    "build": "node-binary\\node node_modules\\vite\\bin\\vite.js build",
-    "lint": "node-binar\\/node node_modules\\eslint/bin\\eslint.js .",
-    "preview": "node-binary\\node node_modules\\vite/bin\\vite.js preview",
-    "format": "node-binary\\node node_modules\\prettier\\bin-prettier.js -c src",
-    "format:fix": "node-binary\\node node_modules\\prettier\\bin-prettier.js -w src"
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview",
+    "format": "prettier -c src",
+    "format:fix": "prettier -w src"
   },
   "dependencies": {
     "@heroicons/react": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "server": "json-server --watch db.json --port 4000",
+    "dev": "node-binary\\node node_modules\\vite\\bin\\vite.js",
+    "server": "node-binary\\node node_modules\\json-server\\lib\\cli\\bin.js --watch db.json --port 4000",
     "start": "concurrently \"npm:dev\" \"npm:server\"",
-    "build": "tsc -b && vite build",
-    "lint": "eslint .",
-    "preview": "vite preview",
-    "format": "prettier -c src",
-    "format:fix": "prettier -w src"
+    "build": "node-binary\\node node_modules\\vite\\bin\\vite.js build",
+    "lint": "node-binar\\/node node_modules\\eslint/bin\\eslint.js .",
+    "preview": "node-binary\\node node_modules\\vite/bin\\vite.js preview",
+    "format": "node-binary\\node node_modules\\prettier\\bin-prettier.js -c src",
+    "format:fix": "node-binary\\node node_modules\\prettier\\bin-prettier.js -w src"
   },
   "dependencies": {
     "@heroicons/react": "^2.1.5",


### PR DESCRIPTION
Created batch file that runs `npm start` to run the project without opening the terminal typing it in yourself, as well as automatically opening chrome at `http://localhost:3000`
<details>
<summary>.bat code</summary>

```bat
@echo off

:: Open Chrome browser with the specified URL
start chrome "http://localhost:3000"

:: Run npm start
npm start

:: Prevent the terminal from closing immediately
pause

```

</details>

Also, the switch to portable node was reverted because it caused major issues that messed up the entire frontend, specifically tailwind.

Even with a timeout to space out the `npm start` and running chrome, the response for `npm start` is as normal until the `start chrome` command is run, which is when this error message appears.  The likely issue was a mistake in implementing the portable node but it was such a complicated problem that was too risky to implement now since the page is still being actively developed and involved modifying the `package.json` file so I decided to handle it next time.

if anyone is willing to take a go at it, here is the error message:

<details>
<summary>error message</summary>

```bash
[dev] file:///C:/Users/DarryllV/Documents/1.%20NYP%20stuff/Y3S2/(EGL304)%20Infocomm%20System%20Project/Senior-Resident-Scheduling/tailwind.config.js:2
[dev] module.exports = {
[dev] ^
[dev]
[dev] ReferenceError: module is not defined
[dev]     at file:///C:/Users/DarryllV/Documents/1.%20NYP%20stuff/Y3S2/(EGL304)%20Infocomm%20System%20Project/Senior-Resident-Scheduling/tailwind.config.js:2:1
[dev]     at ModuleJobSync.runSync (node:internal/modules/esm/module_job:395:35)
[dev]     at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:329:47)
[dev]     at loadESMFromCJS (node:internal/modules/cjs/loader:1414:24)
[dev]     at Module._compile (node:internal/modules/cjs/loader:1547:5)
[dev]     at Object..js (node:internal/modules/cjs/loader:1677:16)
[dev]     at Module.load (node:internal/modules/cjs/loader:1318:32)
[dev]     at Function._load (node:internal/modules/cjs/loader:1128:12)
[dev]     at TracingChannel.traceSync (node:diagnostics_channel:322:14)
[dev]     at wrapModuleLoad (node:internal/modules/cjs/loader:219:24)
[dev]     at Module.require (node:internal/modules/cjs/loader:1340:12)
[dev]     at require (node:internal/modules/helpers:138:16)
[dev]     at C:\Users\DarryllV\Documents\1. NYP stuff\Y3S2\(EGL304) Infocomm System Project\Senior-Resident-Scheduling\node_modules\tailwindcss\lib\lib\load-config.js:54:27
[dev]     at loadConfig (C:\Users\DarryllV\Documents\1. NYP stuff\Y3S2\(EGL304) Infocomm System Project\Senior-Resident-Scheduling\node_modules\tailwindcss\lib\lib\load-config.js:58:6)
[dev]     at getTailwindConfig (C:\Users\DarryllV\Documents\1. NYP stuff\Y3S2\(EGL304) Infocomm System Project\Senior-Resident-Scheduling\node_modules\tailwindcss\lib\lib\setupTrackingContext.js:71:116)
[dev]     at C:\Users\DarryllV\Documents\1. NYP stuff\Y3S2\(EGL304) Infocomm System Project\Senior-Resident-Scheduling\node_modules\tailwindcss\lib\lib\setupTrackingContext.js:100:92
[dev]     at C:\Users\DarryllV\Documents\1. NYP stuff\Y3S2\(EGL304) Infocomm System Project\Senior-Resident-Scheduling\node_modules\tailwindcss\lib\processTailwindFeatures.js:46:11
[dev]     at plugins (C:\Users\DarryllV\Documents\1. NYP stuff\Y3S2\(EGL304) Infocomm System Project\Senior-Resident-Scheduling\node_modules\tailwindcss\lib\plugin.js:38:69)
[dev]     at LazyResult.runOnRoot (C:\Users\DarryllV\Documents\1. NYP stuff\Y3S2\(EGL304) Infocomm System Project\Senior-Resident-Scheduling\node_modules\postcss\lib\lazy-result.js:329:16)
[dev]     at LazyResult.runAsync (C:\Users\DarryllV\Documents\1. NYP stuff\Y3S2\(EGL304) Infocomm System Project\Senior-Resident-Scheduling\node_modules\postcss\lib\lazy-result.js:258:26)
[dev]     at async compileCSS (file:///C:/Users/DarryllV/Documents/1.%20NYP%20stuff/Y3S2/(EGL304)%20Infocomm%20System%20Project/Senior-Resident-Scheduling/node_modules/vite/dist/node/chunks/dep-BWSbWtLw.js:36897:21)
[dev]     at async TransformPluginContext.transform (file:///C:/Users/DarryllV/Documents/1.%20NYP%20stuff/Y3S2/(EGL304)%20Infocomm%20System%20Project/Senior-Resident-Scheduling/node_modules/vite/dist/node/chunks/dep-BWSbWtLw.js:36170:11)
[dev]     at async PluginContainer.transform (file:///C:/Users/DarryllV/Documents/1.%20NYP%20stuff/Y3S2/(EGL304)%20Infocomm%20System%20Project/Senior-Resident-Scheduling/node_modules/vite/dist/node/chunks/dep-BWSbWtLw.js:49096:18)
[dev]     at async loadAndTransform (file:///C:/Users/DarryllV/Documents/1.%20NYP%20stuff/Y3S2/(EGL304)%20Infocomm%20System%20Project/Senior-Resident-Scheduling/node_modules/vite/dist/node/chunks/dep-BWSbWtLw.js:51929:27)
[dev]
[dev] Node.js v22.12.0
[dev] npm run dev exited with code 1
```

</details>